### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-install-recommends -y \
+    jq curl git \
+    python3-minimal python3-pip \
+    && pip3 install gitlint \
+    && apt-get purge -y --auto-remove python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY bin/git-burn /usr/bin/
+COPY share/git-burn/gitlint* /usr/share/git-burn/
+
+ENTRYPOINT ["/usr/bin/git-burn"]


### PR DESCRIPTION
Using snap is sadly not particularly portable. For example, it's impossible to use them from Docker. Modern CI are frequently built on Docker, and as running git-burn explicitly as a CI job might be useful.