### PR TITLE
Fix unbound EMAILS variable

### DIFF
--- a/bin/git-burn
+++ b/bin/git-burn
@@ -167,6 +167,7 @@ fetch-mails() {
 }
 
 fetch-mails-from-gitlab() {
+    EMAILS=""
     [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] && return 0
     EMAILS=$(curl --silent --show-error \
                   --header "Private-Token: $GITLAB_TOKEN" \


### PR DESCRIPTION
This happens when GitLab token and/or URL are unset.

In debug mode, this led to explicit "line 99: EMAILS: unbound variable"
failure, but in the default mode, this led to silent failure.