### PR TITLE
Use curl --fail for retrieving e-mails

### DIFF
--- a/bin/git-burn
+++ b/bin/git-burn
@@ -169,7 +169,7 @@ fetch-mails() {
 fetch-mails-from-gitlab() {
     EMAILS=""
     [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] && return 0
-    EMAILS=$(curl --silent --show-error \
+    EMAILS=$(curl --silent --show-error --fail \
                   --header "Private-Token: $GITLAB_TOKEN" \
                   "$GITLAB_URL/api/v4/users/?active=true&per_page=1000" \
              | jq -r '.[].email' \


### PR DESCRIPTION
This option causes cURL to exit with non-zero status when server returns an HTTP error, like 403.

This prevents confusing errors when token is invalid:

    $ git-burn --rev-list "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME..$CI_COMMIT_SHA"
    jq: error (at <stdin>:0): Cannot index string with string "email"

And will return the error like this instead:

    curl: (22) The requested URL returned error: 401