### PR TITLE
Show committer e-mail in failure message

### DIFF
--- a/bin/git-burn
+++ b/bin/git-burn
@@ -118,7 +118,7 @@ EOF
             echo "Git Burn rejected your commits."; echo
         fi
 
-        git log -1 "$commit"; echo
+        git log -1 --format=fuller "$commit"; echo
         echo "$result"; echo
         status=1
     done


### PR DESCRIPTION
The committer e-mail is also verified, but it is used to be not shown on failure, leading to misleading message.